### PR TITLE
fix(deploy): Cloud Runのポート設定を修正しデプロイエラーを解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,13 @@ FROM nginx:stable-alpine
 # Copy the built assets from the build stage
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# Copy the custom Nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy the Nginx configuration template and the startup script
+COPY nginx.conf.template /etc/nginx/conf.d/nginx.conf.template
+COPY start.sh /start.sh
 
-# Expose port 80 and start Nginx
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+# Make the startup script executable
+RUN chmod +x /start.sh
+
+# Expose port 8080 and start the application using the script
+EXPOSE 8080
+CMD ["/start.sh"]

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen __PORT__;
 
   root /usr/share/nginx/html;
   index index.html;

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Replace the placeholder with the PORT environment variable
+envsubst < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf
+
+# Start Nginx
+nginx -g 'daemon off;'


### PR DESCRIPTION


#### 概要

Cloud Runへのデプロイが、コンテナが指定されたポートでリッスンを開始できない問題により失敗していました。
このPRでは、Nginxの設定を動的に変更し、Cloud Runから環境変数 `PORT` で渡されるポート番号でリッスンするように修正します。

#### 変更内容

- **`nginx.conf` を `nginx.conf.template` に変更:**
  - Nginxのlistenポートをハードコードされた `80` から、置換用のプレースホルダー `__PORT__` に変更しました。
- **`start.sh` スクリプトの追加:**
  - コンテナ起動時に `envsubst` コマンドを使い、`nginx.conf.template` の `__PORT__` を環境変数 `$PORT` の値で置換し、`/etc/nginx/conf.d/default.conf` として出力します。
  - その後、Nginxをフォアグラウンドで起動します。
- **`Dockerfile` の更新:**
  - `nginx.conf.template` と `start.sh` をコンテナイメージにコピーします。
  - `start.sh` に実行権限を付与します。
  - コンテナの起動コマンドを `start.sh` の実行に変更しました。
  - `EXPOSE` するポートを `8080` に変更しました。

#### 影響範囲

- Cloud Runへのデプロイプロセス
- 本番環境のコンテナランタイム

#### 確認方法

1.  このブランチをCloud Build経由でデプロイする
2.  デプロイが正常に完了し、アプリケーションにアクセスできることを確認する

