### PR TITLE
`fix(deploy): Nginxの設定生成を修正しCloud Runのデプロイエラーを解消`

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-  listen __PORT__;
+  listen ${PORT};
 
   root /usr/share/nginx/html;
   index index.html;

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-# Replace the placeholder with the PORT environment variable
-envsubst < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf
+# Replace the '${PORT}' placeholder with the PORT environment variable
+envsubst '${PORT}' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf
+
+# Output the generated config file for debugging
+echo "--- Generated nginx.conf ---"
+cat /etc/nginx/conf.d/default.conf
+echo "--------------------------"
 
 # Start Nginx
 nginx -g 'daemon off;'


### PR DESCRIPTION


#### 概要

前回までの修正後も、Cloud RunへのデプロイがNginxのエラーで失敗する問題が継続していました。
調査の結果、コンテナ起動時にNginxの設定ファイルを生成する `envsubst` コマンドの使用方法に誤りがあり、ポート番号の置換が正しく行われていなかったことが原因でした。

このPRでは、`envsubst` が正しく動作するように設定テンプレートと起動スクリプトを修正し、デプロイを正常に完了させることを目的とします。

#### 変更内容

- **`nginx.conf.template` の修正:**
  - `envsubst` が置換対象として認識できるよう、ポートのプレースホルダーを `__PORT__` から `${PORT}` に変更しました。
- **`start.sh` の修正:**
  - `envsubst` コマンドに、置換対象の変数として `'${PORT}'` を明示的に指定するように変更しました。
  - 将来のデバッグを容易にするため、スクリプトが生成したNginxの設定ファイルの内容を `cat` コマンドで標準出力に表示する処理を追加しました。

#### 確認方法

1.  このブランチをCloud Build経由でデプロイする
2.  Cloud Buildのログで、`start.sh` によってNginxの設定ファイルが正しく生成されていることを確認する
3.  デプロイが正常に完了し、アプリケーションにアクセスできることを確認する

