### PR TITLE
fix(deploy): ビルド時の環境変数を修正し、Google連携とバージョン表示を正常化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /app
 # Example: --build-arg VITE_GEMINI_API_KEY="your_key"
 ARG VITE_GEMINI_API_KEY
 ARG VITE_GOOGLE_API_KEY
+ARG VITE_GOOGLE_CLIENT_ID
+ARG VITE_APP_VERSION
+ARG VITE_BUILD_TIMESTAMP
 
 # Copy package files and install dependencies
 COPY package*.json ./
@@ -21,6 +24,9 @@ COPY . .
 # This file will only exist within this build stage and won't be in the final image.
 RUN echo "VITE_GEMINI_API_KEY=${VITE_GEMINI_API_KEY}" > .env
 RUN echo "VITE_GOOGLE_API_KEY=${VITE_GOOGLE_API_KEY}" >> .env
+RUN echo "VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}" >> .env
+RUN echo "VITE_APP_VERSION=${VITE_APP_VERSION}" >> .env
+RUN echo "VITE_BUILD_TIMESTAMP=${VITE_BUILD_TIMESTAMP}" >> .env
 
 # Build the application
 RUN npm run build

--- a/services/googleDriveService.ts
+++ b/services/googleDriveService.ts
@@ -12,8 +12,12 @@ const API_KEY_KEY = 'gdrive_api_key';
 const SPREADSHEET_NAME = 'AI-Diary-Backup';
 const SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/spreadsheets';
 
-const getGoogleClientId = (): string | null => localStorage.getItem(CLIENT_ID_KEY);
-const getGoogleApiKey = (): string | null => localStorage.getItem(API_KEY_KEY);
+const getGoogleClientId = (): string | null => {
+    return localStorage.getItem(CLIENT_ID_KEY) || import.meta.env.VITE_GOOGLE_CLIENT_ID || null;
+};
+const getGoogleApiKey = (): string | null => {
+    return localStorage.getItem(API_KEY_KEY) || import.meta.env.VITE_GOOGLE_API_KEY || null;
+};
 
 declare global {
     interface Window {


### PR DESCRIPTION

#### 概要

デプロイ後のアプリケーションで、以下の2つの問題が発生していました。
1.  Google Drive連携機能が認証エラーで動作しない。
2.  サイドバーに表示されるべきバージョン情報が表示されない。

調査の結果、両方の問題とも、アプリケーションのビルド時にViteが必要とする環境変数が正しく渡されていないことが根本的な原因でした。

このPRでは、ビルドプロセスとアプリケーションコードを修正し、これらの問題をまとめて解決します。

#### 変更内容

1.  **`services/googleDriveService.ts` の修正:**
    - Google APIの認証情報を `localStorage` からのみ読み込んでいたロジックを修正。
    - `localStorage` に値がない場合、ビルド時に埋め込まれた環境変数 (`VITE_GOOGLE_API_KEY`, `VITE_GOOGLE_CLIENT_ID`) をフォールバックとして使用するように変更しました。

2.  **`Dockerfile` の修正:**
    - アプリケーションが必要とするすべての環境変数 (`VITE_GOOGLE_CLIENT_ID`, `VITE_APP_VERSION`, `VITE_BUILD_TIMESTAMP`) を、`docker build` 時にビルド引数 (`ARG`) として受け取れるように定義を追加しました。
    - 受け取った引数を、ビルド時にViteが参照する `.env` ファイルに書き込む処理を追加しました。

#### お客様へのお願い：Cloud Build 設定の更新

この修正を完全に有効にするには、Cloud BuildのYAMLファイルを更新し、`docker build` ステップで追加したビルド引数を渡す必要があります。

**修正例：**
```yaml
steps:
  - name: gcr.io/cloud-builders/docker
    args:
      - build
      - '--build-arg'
      - 'VITE_GEMINI_API_KEY=${_GEMINI_API_KEY}'
      - '--build-arg'
      - 'VITE_GOOGLE_API_KEY=${_GOOGLE_API_KEY}'
      # ↓↓↓ 以下の3つの --build-arg を追加 ↓↓↓
      - '--build-arg'
      - 'VITE_GOOGLE_CLIENT_ID=${_GOOGLE_CLIENT_ID}' # ご自身の環境の変数名に要変更
      - '--build-arg'
      - 'VITE_APP_VERSION=$SHORT_SHA'
      - '--build-arg'
      - 'VITE_BUILD_TIMESTAMP=$(date -u +''%Y-%m-%dT%H:%M:%SZ'')'
      # ↑↑↑ ここまで追加 ↑↑↑
      - '-t'
      - 'gcr.io/$PROJECT_ID/ai-driven-diary:$COMMIT_SHA'
      - .
```

#### 確認方法

1.  Cloud BuildのYAMLファイルを上記のように修正する。
2.  このブランチをマージし、Cloud Build経由でデプロイを実行する。
3.  デプロイされたアプリケーションを開き、以下の2点を確認する。
    - サイドバー左下にバージョンとビルド情報（コミットハッシュなど）が表示されること。
    - Google Drive連携機能（バックアップなど）がエラーなく正常に動作すること。

