### PR TITLE
docs: READMEに環境URLを追記し、古い情報を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@
 *   **セキュアな認証:** あなたの日記をプライベートに保つためのユーザー認証。
 *   **Googleドライブへのエクスポート:** 日記のエントリーをGoogleドライブアカウントにエクスポートします。
 
+## URL
+
+- **本番環境:** `https://ai-driven-diary-325560862981.asia-northeast1.run.app/`
+- **ローカル開発環境:** `http://localhost:5173`
+
 ---
-
-# AI Studioアプリの実行とデプロイ
-
-ここには、アプリをローカルで実行するために必要なものがすべて含まれています。
-
-AI Studioでアプリを表示: https://ai.studio/apps/drive/1PLYbSuRJP-CXHoawr8UfsPregx3-xgqi
 
 ## ローカルでの実行
 


### PR DESCRIPTION
Cloud Runへのデプロイ先URLが変更されたことに伴い、開発者が参照する情報を最新の状態に保つため`README.md`を更新します。

#### 変更内容

- 古いAI Studioのデプロイに関するセクションを削除しました。
- 本番環境とローカル開発環境のURLを明記した新しい「URL」セクションを追加しました。

これにより、プロジェクトの正しいアクセス先が明確になり、URLの混乱を防ぎます。
